### PR TITLE
Fixed application crashes from too many open file handles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,16 +4,16 @@ GOBUILD=$(GOCMD) build
 GOCLEAN=$(GOCMD) clean
 GOTEST=$(GOCMD) test
 GOGET=$(GOCMD) get
-BINARY_NAME=kafka-topic-usage
+BINARY_NAME=kafka-topic-usage-exporter
 BINARY_UNIX=$(BINARY_NAME)_unix
 
 all: test build
-build: 
+build:
 	$(GOBUILD) -o $(BINARY_NAME) -v
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GOBUILD) -o $(BINARY_UNIX) -v
-test: 
+test:
 	$(GOTEST) -v ./...
-clean: 
+clean:
 	$(GOCLEAN)
 	rm -f $(BINARY_NAME)
 	rm -f $(BINARY_UNIX)

--- a/config.yaml
+++ b/config.yaml
@@ -1,11 +1,7 @@
-data_dirs: 
+data_dirs:
    - "/tmp/kafka-logs"
 cluster: "test1"
 delay: 1
 prom_file: "prom/test.prom"
-topics:
-  - "test-0"
-  - "test-1"
-  - "test-2"
 brokers:
    - localhost:9092

--- a/kafka-topic-usage-exporter.go
+++ b/kafka-topic-usage-exporter.go
@@ -38,6 +38,7 @@ func main() {
 
 	for {
 		topics := GetKafkaTopics(brokers)
+
 		hostname, err := os.Hostname()
 		if err != nil {
 			panic(err)
@@ -52,11 +53,12 @@ func main() {
 
 			for _, topic := range topics {
 				var topicSize int64
+				topicSize = 0
 				for _, file := range dirListing {
 					topic := topic + "-"
 					if strings.HasPrefix(file.Name(), topic) {
 						dirname := path.Join(logDir, file.Name())
-						topicSize = topicSize + DirSizeBytes(dirname)
+						topicSize = topicSize + GetDirSizeBytes(dirname)
 					}
 				}
 				var message = fmt.Sprintf("kafka_topic_disk_usage_bytes{kafka_log_dir=\"%v\", kafka_topic=\"%v\", kafka_node=\"%v\", kafka_cluster=\"%v\"} %v\n", logDir, topic, hostname, cluster, topicSize)
@@ -77,7 +79,7 @@ func main() {
 /*
  get the directory size in bytes
 */
-func DirSizeBytes(path string) int64 {
+func GetDirSizeBytes(path string) int64 {
 
 	var dirSize int64
 
@@ -90,7 +92,6 @@ func DirSizeBytes(path string) int64 {
 	}
 
 	filepath.Walk(path, readSize)
-
 	return dirSize
 }
 
@@ -103,6 +104,7 @@ func GetKafkaTopics(brokers []string) []string {
 
 	if err == nil {
 		topics, _ = consumer.Topics()
+		consumer.Close()
 	}
 
 	return topics


### PR DESCRIPTION
- Added close() to kafka client
- Renamed binary to `kafka-topic-usage-exporter`
- Renamed `DirSizeBytes` to `GetDirSizeBytes`
- Removed `topics` from sample config
